### PR TITLE
Fix crash when node_cave_liquid is a table

### DIFF
--- a/lib_mg_continental_voxel.lua
+++ b/lib_mg_continental_voxel.lua
@@ -404,7 +404,11 @@ end
 			r_biome = r_biome .. b_riverbed_depth .. "|"
 
 			if desc.node_cave_liquid and desc.node_cave_liquid ~= ""  then
-				b_cave_liquid = minetest.get_content_id(desc.node_cave_liquid)
+				local node_cave_liquid = desc.node_cave_liquid
+				if type(node_cave_liquid) == "table" then -- Workaround to deal with tables
+					node_cave_liquid = node_cave_liquid[1]
+				end
+				b_cave_liquid = minetest.get_content_id(node_cave_liquid)
 			else
 				b_cave_liquid = minetest.get_content_id("default:lava_source")
 			end


### PR DESCRIPTION
I got this crash
```
2020-04-06 19:25:51: ERROR[Main]: ModError: Failed to load and run script from /home/gael/.minetest/mods/lib_mg_continental/init.lua:
2020-04-06 19:25:51: ERROR[Main]: ...est/mods/lib_mg_continental/lib_mg_continental_voxel.lua:407: bad argument #1 to 'get_content_id' (string expected, got table)
2020-04-06 19:25:51: ERROR[Main]: stack traceback:
2020-04-06 19:25:51: ERROR[Main]: 	[C]: in function 'get_content_id'
2020-04-06 19:25:51: ERROR[Main]: 	...est/mods/lib_mg_continental/lib_mg_continental_voxel.lua:407: in main chunk
2020-04-06 19:25:51: ERROR[Main]: 	[C]: in function 'dofile'
2020-04-06 19:25:51: ERROR[Main]: 	/home/gael/.minetest/mods/lib_mg_continental/init.lua:47: in main chunk
```
I propose a workaround by taking the first element of `node_cave_liquid` when it's a table. I don't know how you want to deal with the table but at least this prevents the crash.